### PR TITLE
Fix quantity check in checkout

### DIFF
--- a/src/pages/shop/CheckoutPage.jsx
+++ b/src/pages/shop/CheckoutPage.jsx
@@ -96,8 +96,8 @@ const CheckoutPage = () => {
 
         const product = docSnap.data();
         const sizeObj = product.sizes.find((s) => s.size === item.size);
-        if (!sizeObj || sizeObj.stock < item.quantity) {
-          toast.error(`Only ${sizeObj?.stock || 0} left for ${item.productName} (${item.size})`);
+        if (!sizeObj || sizeObj.quantity < item.quantity) {
+          toast.error(`Only ${sizeObj?.quantity || 0} left for ${item.productName} (${item.size})`);
           setValidating(false);
           return;
         }
@@ -130,7 +130,7 @@ const CheckoutPage = () => {
         const docRef = doc(db, "products", item.productId);
         const product = (await getDoc(docRef)).data();
         const updatedSizes = product.sizes.map((s) =>
-          s.size === item.size ? { ...s, stock: s.stock - item.quantity } : s
+          s.size === item.size ? { ...s, quantity: s.quantity - item.quantity } : s
         );
         await updateDoc(docRef, { sizes: updatedSizes });
       }


### PR DESCRIPTION
## Summary
- adjust checkout logic to use the `quantity` field in product sizes

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c059a1908328b40c176fb089ac66